### PR TITLE
Refactoring and simplifying

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -12,7 +12,7 @@ By default, <tt>attr_enumerator</tt> will create:
 The module is automatically included in <tt>ActiveRecord::Base</tt> and is available for use in all <tt>ActiveRecord</tt> models. 
 
   class Car < ActiveRecord::Base
-    attr_enumerator :color, ['red', 'blue']
+    attr_enumerator :color, :in => ['red', 'blue']
   end
 
 To use <tt>attr_enumerator</tt> on a class that does not descend from <tt>ActiveRecord::Base</tt> it must include <tt>ActiveModel::Validations</tt> and provide an accessor to the attribute.
@@ -22,44 +22,18 @@ To use <tt>attr_enumerator</tt> on a class that does not descend from <tt>Active
     include AttrEnumerator
 
     attr_accessor :color
-    attr_enumerator :color, ['red', 'blue']
-  end
-
-== Configuration
-
-Options may be passed to <tt>attr_enumerator</tt> to configure its behavior. For instance, use <tt>:create_constant => false</tt> to prevent a class constant from being created.
-
-  class Car < ActiveRecord::Base
-    attr_enumerator :color, ['red', 'blue'], :create_constant => false
-  end
-
-Options can also be configured globally using the following syntax. Options passed directly to <tt>attr_enumerator</tt> will override global options.
-
-  AttrEnumerator::Options.configure do |config|
-    config.create_constant = false
+    attr_enumerator :color, :in => ['red', 'blue']
   end
 
 === Options
-* <tt>create_constant</tt> (default: <tt>true</tt>)
+* <tt>constant</tt>
 
-  When <tt>true</tt>, a class constant containing an array of choices is created using the pluralized, uppercased attribute name. Set to a string or symbol to change the constant name or <tt>false</tt> to not create a constant.
+  Defines the constant name for the enumeration.  By default, the pluralized, upper-case form of the attribute name is used.  (e.g. COLORS if attr is color, ENGINE_TYPES if attr is engine_type)
   
-* <tt>create_methods</tt> (default: <tt>true</tt>)
-
-  When <tt>true</tt>, create a method for each choice that returns <tt>true</tt> if the attribute is that value and <tt>false</tt> otherwise. Use the <tt>prefix</tt> and <tt>suffix</tt> options to customize the method names. Set to <tt>false</tt> to not create methods.
-
-* <tt>create_scopes</tt> (default: <tt>true</tt>, ignored when not using <tt>ActiveRecord</tt>)
-
-  When <tt>true</tt>, create a scope for each choice that retrieves records where the attribute is that value. Use the <tt>prefix</tt> and <tt>suffix</tt> options to customize the scope names. Set to <tt>false</tt> to not create scopes.
-
 * <tt>prefix</tt> (default: <tt>true</tt>)
 
   When <tt>true</tt>, prefixes created methods and scopes with the attribute name. Set to a string or symbol to change the prefix or <tt>false</tt> to disable.
   
-* <tt>suffix</tt> (default: <tt>false</tt>)
-
-  See <tt>prefix</tt>.
-
 * <tt>message</tt> (default: <tt>'is invalid'</tt>)
 
   Specifies the error message when the attribute is not a valid value. Use <tt>%{value}</tt> to refer to the value of the attribute, e.g. <tt>"%{value} is not a valid choice"</tt>.

--- a/README.rdoc
+++ b/README.rdoc
@@ -15,7 +15,7 @@ The module is automatically included in <tt>ActiveRecord::Base</tt> and is avail
     attr_enumerator :color, :in => ['red', 'blue']
   end
 
-The above invocation the following to Car:
+The above invocation adds the following to Car:
   car = Car.new
   car.color = 'red'
   car.save

--- a/README.rdoc
+++ b/README.rdoc
@@ -30,11 +30,10 @@ To use <tt>attr_enumerator</tt> on a class that does not descend from <tt>Active
 
   Defines the constant name for the enumeration.  By default, the pluralized, upper-case form of the attribute name is used.  (e.g. COLORS if attr is color, ENGINE_TYPES if attr is engine_type)
   
-* <tt>prefix</tt> (default: <tt>true</tt>)
-
-  When <tt>true</tt>, prefixes created methods and scopes with the attribute name. Set to a string or symbol to change the prefix or <tt>false</tt> to disable.
+* <tt>prefix</tt>
+  Set a custom prefix for methods and scopes.  By default, the field's name is used as a prefix.  Set to <tt>false</tt> to disable.
   
-* <tt>message</tt> (default: <tt>'is invalid'</tt>)
+* <tt>message</tt> (default: <tt>:invalid</tt>)
 
   Specifies the error message when the attribute is not a valid value. Use <tt>%{value}</tt> to refer to the value of the attribute, e.g. <tt>"%{value} is not a valid choice"</tt>.
 

--- a/README.rdoc
+++ b/README.rdoc
@@ -31,6 +31,7 @@ To use <tt>attr_enumerator</tt> on a class that does not descend from <tt>Active
   Defines the constant name for the enumeration.  By default, the pluralized, upper-case form of the attribute name is used.  (e.g. COLORS if attr is color, ENGINE_TYPES if attr is engine_type)
   
 * <tt>prefix</tt>
+
   Set a custom prefix for methods and scopes.  By default, the field's name is used as a prefix.  Set to <tt>false</tt> to disable.
   
 * <tt>message</tt> (default: <tt>:invalid</tt>)

--- a/README.rdoc
+++ b/README.rdoc
@@ -15,7 +15,18 @@ The module is automatically included in <tt>ActiveRecord::Base</tt> and is avail
     attr_enumerator :color, :in => ['red', 'blue']
   end
 
-To use <tt>attr_enumerator</tt> on a class that does not descend from <tt>ActiveRecord::Base</tt> it must include <tt>ActiveModel::Validations</tt> and provide an accessor to the attribute.
+The above invocation the following to Car:
+  car = Car.new
+  car.color = 'red'
+  car.save
+
+  car.color_red?  # => true
+  car.color_blue? # => false
+  
+  Car.color_red   # => [<#Car>]
+  Car.COLORS      # => ['red', 'blue']
+
+To use <tt>attr_enumerator</tt> on a class that does not descend from <tt>ActiveRecord::Base</tt> it must include <tt>ActiveModel::Validations</tt> and provide an accessor to the attribute.  
 
   class Car
     include ActiveModel::Validations

--- a/lib/attr_enumerator.rb
+++ b/lib/attr_enumerator.rb
@@ -3,71 +3,27 @@ require 'active_support'
 
 module AttrEnumerator
   extend ActiveSupport::Concern
-
+  
   module ClassMethods
-    def attr_enumerator(field, choices, opts={})
-      options = Options.parse(field, choices, opts, self)
+    def attr_enumerator(field, options = {})
+      choices = options[:in]
+      constant = options.delete(:constant) || field.to_s.pluralize.upcase
+      options[:message] ||= :invalid
+      
+      const_set(constant, choices).freeze
+      validates field, :inclusion => options
+      
+      choice_prefix = options.has_key?(:prefix) ? (options[:prefix] ? options[:prefix].to_s + '_' : '') : field.to_s + '_'
 
-      validates field, :inclusion => options[:validation_options]
-
-      if options[:create_constant]
-        const_set(options[:constant], choices).freeze
-      end
-
-      options[:formatted_choices].each do |formatted_choice, choice|
-        if options[:create_methods]
-          define_method(formatted_choice + '?'){ self.send(field) == choice }
+      choices.each do |choice|
+        field_choice = choice_prefix + choice.to_s.underscore.parameterize('_')
+        define_method("#{field_choice}?") do
+          self.send(field) == choice
         end
-
-        if options[:create_scopes]
-          scope formatted_choice, where(field => choice)
-        end
-      end
-    end
-  end
-
-  class Options
-    include ActiveSupport::Configurable
-
-    config.create_constant  = true
-    config.create_methods   = true
-    config.create_scopes    = true
-    config.prefix           = true
-    config.suffix           = false
-    config.message          = :invalid
-
-    VALIDATION_OPTIONS = [:in, :message, :allow_nil, :allow_blank, :if, :unless].freeze
-
-    def self.parse(field, choices, opts, klass)
-      {}.merge!(config).merge!(opts).merge!(:in => choices).tap do |options|
-        options[:validation_options] = options.slice(*VALIDATION_OPTIONS)
-        options.reject!{ |k,v| VALIDATION_OPTIONS.include?(k) }
-
-        options[:create_scopes] &= klass.respond_to?(:scope)
-
-        [:prefix, :suffix].each do |affix|
-          options[affix] = case options[affix]
-          when true then field.to_s
-          when false then nil
-          else options[affix].to_s
-          end
-        end
-
-        options[:constant] = case options[:create_constant]
-        when true then field.to_s.pluralize.upcase
-        when false then nil
-        else options[:create_constant].to_s
-        end
-
-        options[:formatted_choices] = choices.map do |choice|
-          formatted_choice = choice.to_s.underscore.parameterize('_')
-          formatted_choice.insert(0, options[:prefix] + '_') unless options[:prefix].blank?
-          formatted_choice << '_' + options[:suffix] unless options[:suffix].blank?
-          [formatted_choice, choice]
-        end
+        scope field_choice, where(field => choice) if self.respond_to? :scope
       end
     end
   end
 end
 
-ActiveRecord::Base.class_eval { include AttrEnumerator } if defined? ActiveRecord
+ActiveRecord::Base.send :include, AttrEnumerator if defined? ActiveRecord

--- a/spec/attr_enumerator_spec.rb
+++ b/spec/attr_enumerator_spec.rb
@@ -25,32 +25,32 @@ describe "AttrEnumerator" do
 
     context "validation" do
       it "should pass when the value is one of the choices" do
-        subject.attr_enumerator :choice, ['red', 'blue']
+        subject.attr_enumerator :choice, :in => ['red', 'blue']
         instance.choice = 'blue'
         instance.should be_valid
       end
 
       it "should fail when the value is not one of the choices" do
-        subject.attr_enumerator :choice, ['red', 'blue']
+        subject.attr_enumerator :choice, :in => ['red', 'blue']
         instance.choice = 'green'
         instance.should_not be_valid
       end
 
       it "should have a default message" do
-        subject.attr_enumerator :choice, ['red', 'blue']
+        subject.attr_enumerator :choice, :in => ['red', 'blue']
         instance.valid?
         instance.errors.should == {:choice => ['is invalid']}
       end
 
       it "should allow for a custom message" do
-        subject.attr_enumerator :choice, ['red', 'blue'], :message => '%{value} is not a valid color'
+        subject.attr_enumerator :choice, :in => ['red', 'blue'], :message => '%{value} is not a valid color'
         instance.choice = 'green'
         instance.valid?
         instance.errors.should == {:choice => ['green is not a valid color']}
       end
 
       it "should handle allow_blank" do
-        subject.attr_enumerator :choice, ['red', 'blue'], :allow_blank => true
+        subject.attr_enumerator :choice, :in => ['red', 'blue'], :allow_blank => true
 
         instance.choice = nil
         instance.should be_valid
@@ -60,7 +60,7 @@ describe "AttrEnumerator" do
       end
 
       it "should handle allow_nil" do
-        subject.attr_enumerator :choice, ['red', 'blue'], :allow_nil => true
+        subject.attr_enumerator :choice, :in => ['red', 'blue'], :allow_nil => true
 
         instance.choice = nil
         instance.should be_valid
@@ -69,8 +69,8 @@ describe "AttrEnumerator" do
         instance.should_not be_valid
       end
 
-      it "should handle symbols as enumerations" do
-        subject.attr_enumerator :choice, [:red, :blue]
+      it "should handle symbol enumerations distinctively from strings" do
+        subject.attr_enumerator :choice, :in => [:red, :blue]
 
         instance.choice = :red
         instance.should be_valid
@@ -78,44 +78,35 @@ describe "AttrEnumerator" do
 
         instance.choice = 'red'
         instance.should_not be_valid
+        instance.should_not be_choice_red
       end
     end
 
     context "class constant" do
       it "should create a constant by default" do
-        subject.attr_enumerator :choice, ['red', 'blue']
+        subject.attr_enumerator :choice, :in => ['red', 'blue']
         subject::CHOICES.should == ['red', 'blue']
       end
 
       it "should freeze the constant to prevent editing" do
-        subject.attr_enumerator :choice, ['red', 'blue']
+        subject.attr_enumerator :choice, :in => ['red', 'blue']
         subject::CHOICES.should be_frozen
       end
 
-      it "should allow for explicitly creating the default constant" do
-        subject.attr_enumerator :choice, ['red', 'blue'], :create_constant => true
-        subject::CHOICES.should == ['red', 'blue']
-      end
-
       it "should allow for a custom constant name using a symbol" do
-        subject.attr_enumerator :choice, ['red', 'blue'], :create_constant => :POSSIBLE_COLORS
+        subject.attr_enumerator :choice, :in => ['red', 'blue'], :constant => :POSSIBLE_COLORS
         subject::POSSIBLE_COLORS.should == ['red', 'blue']
       end
 
       it "should allow for a custom constant name using a string" do
-        subject.attr_enumerator :choice, ['red', 'blue'], :create_constant => 'POSSIBLE_COLORS'
+        subject.attr_enumerator :choice, :in => ['red', 'blue'], :constant => 'POSSIBLE_COLORS'
         subject::POSSIBLE_COLORS.should == ['red', 'blue']
-      end
-
-      it "should allow for not creating a constant" do
-        subject.attr_enumerator :choice, ['red', 'blue'], :create_constant => false
-        subject.constants.should_not include('CHOICES')
       end
     end
 
     context "methods" do
       it "should create methods for each enumeration by default" do
-        subject.attr_enumerator :choice, ['red', 'blue']
+        subject.attr_enumerator :choice, :in => ['red', 'blue']
         instance.choice = 'red'
 
         instance.should respond_to :choice_red?
@@ -135,28 +126,15 @@ describe "AttrEnumerator" do
           :ends_with_dot? => 'ends.with.dot.'
         }
 
-        subject.attr_enumerator :choice, enumerations.values, :prefix => false, :suffix => false
+        subject.attr_enumerator :choice, :in => enumerations.values, :prefix => false
 
         enumerations.keys.each do |method_name|
           instance.should respond_to method_name
         end
       end
 
-      it "should allow for explicitly creating the default methods" do
-        subject.attr_enumerator :choice, ['red', 'blue'], :create_methods => true
-        instance.choice = 'red'
-
-        instance.should respond_to :choice_red?
-        instance.should be_choice_red
-      end
-
-      it "should allow for not creating methods" do
-        subject.attr_enumerator :choice, ['red', 'blue'], :create_methods => false
-        instance.should_not respond_to :choice_red?
-      end
-
       it "should allow for a custom prefix" do
-        subject.attr_enumerator :choice, ['red', 'blue'], :prefix => 'colored'
+        subject.attr_enumerator :choice, :in => ['red', 'blue'], :prefix => 'colored'
         instance.choice = 'red'
 
         instance.should respond_to :colored_red?
@@ -165,35 +143,16 @@ describe "AttrEnumerator" do
         instance.should respond_to :colored_blue?
         instance.should_not be_colored_blue
       end
-
-      it "should allow for explicitly using the default prefix" do
-        subject.attr_enumerator :choice, ['red', 'blue'], :prefix => true
-        instance.should respond_to :choice_red?
-      end
-
+      
       it "should allow for no prefix" do
-        subject.attr_enumerator :choice, ['red', 'blue'], :prefix => false
+        subject.attr_enumerator :choice, :in => ['red', 'blue'], :prefix => false
+        instance.choice = 'red'
+
         instance.should respond_to :red?
-      end
+        instance.should be_red
 
-      it "should not have a suffix by default" do
-        subject.attr_enumerator :choice, ['red', 'blue']
-        instance.should respond_to :choice_red?
-      end
-
-      it "should allow for explicitly having no suffix" do
-        subject.attr_enumerator :choice, ['red', 'blue'], :suffix => false
-        instance.should respond_to :choice_red?
-      end
-
-      it "should use the field as a suffix when :suffix is true" do
-        subject.attr_enumerator :choice, ['red', 'blue'], :suffix => true
-        instance.should respond_to :choice_red_choice?
-      end
-
-      it "should allow for a custom suffix" do
-        subject.attr_enumerator :choice, ['red', 'blue'], :suffix => 'custom'
-        instance.should respond_to :choice_red_custom?
+        instance.should respond_to :blue?
+        instance.should_not be_blue
       end
     end
   end
@@ -210,19 +169,19 @@ describe "AttrEnumerator" do
     end
 
     describe "scopes" do
-      it "should create a scope for each enumeration by default" do
-        subject.attr_enumerator :choice, ['red', 'blue']
+      it "should create a scope for each enumeration" do
+        subject.attr_enumerator :choice, :in => ['red', 'blue']
         subject.choice_red.should be_a ActiveRecord::Relation
       end
-
-      it "should allow for explicitly creating scopes" do
-        subject.attr_enumerator :choice, ['red', 'blue'], :create_scopes => true
-        subject.choice_red.should be_a ActiveRecord::Relation
+      
+      it "should create a scope for each enumeration with custom prefix " do
+        subject.attr_enumerator :choice, :in => ['red', 'blue'], :prefix => 'colored'
+        subject.colored_red.should be_a ActiveRecord::Relation
       end
-
-      it "should allow for not creating scopes" do
-        subject.attr_enumerator :choice, ['red', 'blue'], :create_scopes => false
-        subject.should_not respond_to :choice_red
+      
+      it "should create a scope for each enumeration without prefix " do
+        subject.attr_enumerator :choice, :in => ['red', 'blue'], :prefix => false
+        subject.red.should be_a ActiveRecord::Relation
       end
     end
   end


### PR DESCRIPTION
- API Changes
  - Moved choices to :in options
  - Removed options for suffix, method and scope creation, and changed create_constant to constant
- Simplified code
  - Removing separate options configuration
  - Made options more opinionated by removing the ability to disable constant, scope, and method creation-
- Updated README
