### PR TITLE
Rails4 compatibility

### DIFF
--- a/lib/attr_enumerator.rb
+++ b/lib/attr_enumerator.rb
@@ -9,14 +9,14 @@ module AttrEnumerator
       constant = options.delete(:constant) || attribute.to_s.pluralize.upcase
       prefix = options[:prefix] ? options.delete(:prefix).to_s + '_' : ''
       options[:message] ||= :invalid
-      
+
       const_set(constant, choices).freeze
       validates_inclusion_of attribute, options.merge(:in => choices)
 
       choices.each do |choice|
         choice_string = prefix + choice.to_s.underscore.parameterize('_')
         define_method(choice_string + '?') { send(attribute) == choice }
-        scope choice_string, where(attribute => choice) if respond_to? :scope
+        scope choice_string, lambda { where(attribute => choice) } if respond_to? :scope
       end
     end
   end

--- a/spec/attr_enumerator_spec.rb
+++ b/spec/attr_enumerator_spec.rb
@@ -11,7 +11,7 @@ describe "AttrEnumerator" do
         attr_accessor :color
       end
     end
-    
+
     after(:each)  { Object.send(:remove_const, :Car) }
 
     context "validation" do
@@ -30,14 +30,14 @@ describe "AttrEnumerator" do
       it "should have a default message" do
         Car.attr_enumerator :color, ['red', 'blue']
         car.valid?
-        car.errors.should == {:color => ['is invalid']}
+        car.errors[:color].should == ['is invalid']
       end
 
       it "should allow for a custom message" do
         Car.attr_enumerator :color, ['red', 'blue'], :message => '%{value} is not a valid color'
         car.color = 'green'
         car.valid?
-        car.errors.should == {:color => ['green is not a valid color']}
+        car.errors[:color].should == ['green is not a valid color']
       end
 
       it "should handle allow_blank" do
@@ -144,7 +144,7 @@ describe "AttrEnumerator" do
         attr_accessor :color
       end
     end
-    
+
     after(:each)  { Object.send(:remove_const, :Car) }
 
     it "should automatically be included in ActiveRecord::Base" do


### PR DESCRIPTION
- Use lambda in scopes, for rails4 compatibility (scopes must respond to 'call')
- Fix specs treating AR errors as a hash
